### PR TITLE
Do not log any settings at info level

### DIFF
--- a/src/bec.erl
+++ b/src/bec.erl
@@ -80,7 +80,8 @@ specs() ->
     , { keep,        $k, "keep",        {boolean, false}
       , "Keep going after the first error (always true when enforce == true)"}
     , { verbosity,   $v, "verbosity",   {integer, 1}
-      , "Verbosity Level"}
+      , "Verbosity Level. Important: the 'debug' level (-vvv) or higher may "
+        "leak sensitive information in settings."}
     ].
 
 usage() ->

--- a/src/bitbucket_repo_config.erl
+++ b/src/bitbucket_repo_config.erl
@@ -180,9 +180,10 @@ do_verify(ProjectKey, RepoSlug, Key, Expected) ->
     false ->
       %% Not showing details here since they may contain secrets.
       %% They were debug-logged above.
-      ok = ?LOG_ERROR("[~s/~s] Actual does not match Expected"
-                      " (increase verbosity to see details)~n"
-                     , [ProjectKey, RepoSlug]),
+      ok = ?LOG_ERROR(
+              "[~s/~s] Actual does not match Expected. "
+              "Increase verbosity to see details (note: may contain secrets)",
+              [ProjectKey, RepoSlug]),
       false
   end.
 
@@ -262,8 +263,17 @@ do_enforce(ProjectKey, RepoSlug, Key, Expected) ->
   ok = ?LOG_INFO("[~s/~s] Enforcing ~p ~n", [ProjectKey, RepoSlug, Key]),
   Set = setter(Key),
   Adapted = adapt(Key, Expected),
-  ok = ?LOG_INFO("[~s/~s] Setting value to ~p ~n",
-                 [ProjectKey, RepoSlug, Adapted]),
+
+  %% `Adapted' may contain secrets, e.g. the password field in the
+  %% http request post receive hook, so only log that at debug level.
+  ok = ?LOG_INFO(
+          "[~s/~s] Setting value. "
+          "Increase verbosity to see details (note: may contain secrets)",
+          [ProjectKey, RepoSlug]),
+
+  ok = ?LOG_DEBUG("[~s/~s] Setting value to ~p ~n",
+                  [ProjectKey, RepoSlug, Adapted]),
+
   ok = Set(ProjectKey, RepoSlug, Adapted).
 
 -spec remove_global_config(map()) -> map().


### PR DESCRIPTION
This was previously done only by do_verify/4, but it needs to be done in do_enforce/4 as well.