### PR TITLE
Allow injecting OS env vars into YAML files via custom !env tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,8 @@ It is a common need to apply very similar configuration to multiple
 repositories. Repo configuration templates are supported for this use
 case.
 
-A repo configuration file is similar to a repo configuration, but has
-a `.ymlt` extension, and will be rendered as a
+A repo configuration template file is similar to a repo configuration,
+but has a `.ymlt` extension, and will be rendered as a
 [Mustache](https://mustache.github.io/) template. The parameters for
 the template are defined in a `.ymlv` file (as Yaml).
 
@@ -173,6 +173,33 @@ repo:
   - best_cat_pics
 ```
 
+### Handling secrets
+
+Repo configurations may contain secrets, like authentication tokens
+for web hooks. It is possible to inject the secrets at runtime from
+OS environment variables by using the `!env` YAML tag:
+
+```
+- auth_token: !env TOKEN
+```
+
+This tag will fetch the value of the `TOKEN` OS environment variable.
+
+In case a field is not entirely a secret, but contains a secret, repo
+configuration templates can be used:
+
+```
+# example.ymlt
+- auth_token: !env TOKEN
+```
+
+```
+# example.ymlv
+hooks:
+  - key: de.aeffle.stash.plugin.stash-http-get-post-receive-hook:http-get-post-receive-hook
+    settings:
+      url: https://jenkins.hipster.company.io/buildByToken/build?job=fancyci&token={{ auth_token }}
+```
 
 ## Known Limitations
 

--- a/sample_repo_configuration.yml
+++ b/sample_repo_configuration.yml
@@ -144,7 +144,7 @@ webhooks:
     active: true
     url: https://my_endpoint
     configuration:
-      secret: my_secret
+      secret: !env MY_SECRET
     events:
       - pr:modified
       - repo:refs_changed
@@ -152,6 +152,6 @@ webhooks:
     active: true
     url: http://my_other_endpoint
     configuration:
-      secret: my_other_secret
+      secret: !env MY_OTHER_SECRET
     events:
       - pr:modified

--- a/src/bec.erl
+++ b/src/bec.erl
@@ -42,6 +42,7 @@ do_main(Options) ->
     Verbosity = proplists:get_value(verbosity, Options),
     set_logging(verbosity_level(Verbosity)),
     application:ensure_all_started(bec),
+    yamerl_app:set_param(node_mods, [bec_node_env_variable]),
     case bitbucket_config:load(Config) of
         ok ->
             RepoConfig = proplists:get_value(repo_config, Options),

--- a/src/bec_node_env_variable.erl
+++ b/src/bec_node_env_variable.erl
@@ -1,0 +1,51 @@
+%%==============================================================================
+%% YAML node type for accessing OS environment variables.
+%%==============================================================================
+-module(bec_node_env_variable).
+
+-include_lib("yamerl/include/yamerl_errors.hrl").
+-include_lib("yamerl/include/yamerl_tokens.hrl").
+-include_lib("yamerl/include/yamerl_nodes.hrl").
+-include_lib("yamerl/include/internal/yamerl_constr.hrl").
+
+-export([ tags/0
+        , construct_token/3
+        , node_pres/1
+        ]).
+
+-define(TAG, "tag:bec:env").
+
+tags() -> [?TAG, "!env"].
+
+construct_token(#yamerl_constr{detailed_constr = Detailed},
+               undefined,
+               #yamerl_scalar{text = Text} = Token) ->
+  case os:getenv(Text) of
+    false ->
+      parsing_error(Token, "Undefined OS environment variable");
+    Value when Detailed ->
+      Pres = yamerl_constr:get_pres_details(Token),
+      Node = #yamerl_str{ module = ?MODULE
+                        , tag = ?TAG
+                        , pres = Pres
+                        , text = Value
+                        },
+      {finished, Node};
+    Value ->
+      {finished, Value}
+  end;
+construct_token(_, _, Token) ->
+  parsing_error(Token, "Invalid OS environment variable").
+
+node_pres(Node) ->
+    ?NODE_PRES(Node).
+
+parsing_error(Token, Text) ->
+  Error = #yamerl_parsing_error{
+    name   = not_an_os_env,
+    token  = Token,
+    text   = Text,
+    line   = ?TOKEN_LINE(Token),
+    column = ?TOKEN_COLUMN(Token)
+  },
+  throw(Error).

--- a/src/yamerl_nodes.hrl
+++ b/src/yamerl_nodes.hrl
@@ -1,0 +1,11 @@
+%% This is a dummy header file that is needed to be able to
+%%
+%% -include_lib("yamerl/include/internal/yamerl_constr.hrl").
+%%
+%% That header wants to
+%%
+%% -include("yamerl_nodes.hrl").
+%%
+%% which only works if yamerl/include is in the include path, which
+%% is typically not the case outside of the yamerl application.
+%% Creating this header file here is a cheap workaround.

--- a/test/bec_yml_SUITE.erl
+++ b/test/bec_yml_SUITE.erl
@@ -1,0 +1,79 @@
+%%==============================================================================
+%% Test Suite for templates
+%%==============================================================================
+-module(bec_yml_SUITE).
+
+%% Common Test Callbacks
+-export([ all/0
+        , init_per_suite/1
+        , end_per_suite/1
+        , init_per_testcase/2
+        , end_per_testcase/2
+        ]).
+
+%% Testcases
+-export([ environment_variable_substitution/1
+        , missing_environment_variable/1
+        ]).
+
+%%==============================================================================
+%% Include
+%%==============================================================================
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+%%==============================================================================
+%% Types
+%%==============================================================================
+-type config() :: [{atom(), any()}].
+
+%%==============================================================================
+%% Common Test Callbacks
+%%==============================================================================
+-spec all() -> [atom()].
+all() ->
+  ExcludedFuns = [init_per_suite, end_per_suite, all, module_info],
+  Exports = ?MODULE:module_info(exports),
+  [F || {F, 1} <- Exports, not lists:member(F, ExcludedFuns)].
+
+-spec init_per_suite(config()) -> config().
+init_per_suite(Config) ->
+  {ok, Started} = application:ensure_all_started(bec),
+  yamerl_app:set_param(node_mods, [bec_node_env_variable]),
+  [ {started,  Started}
+    | Config
+  ].
+
+-spec end_per_suite(config()) -> ok.
+end_per_suite(Config) ->
+  [application:stop(App) || App <- ?config(started, Config)],
+  ok.
+
+-spec init_per_testcase(atom(), config()) -> any().
+init_per_testcase(_TestCase, Config) ->
+  Config.
+
+-spec end_per_testcase(atom(), config()) -> any().
+end_per_testcase(_TestCase, Config) ->
+  Config.
+
+%%==============================================================================
+%% Test cases
+%%==============================================================================
+-spec environment_variable_substitution(config()) -> ok.
+environment_variable_substitution(_Config) ->
+  Yml = <<"myval: !env TEST_VAL\n">>,
+  try
+    os:putenv("TEST_VAL", "abc"),
+    ?assertEqual([#{<<"myval">> => "abc"}], bec_yml:decode(Yml)),
+    os:putenv("TEST_VAL", "xyz"),
+    ?assertEqual([#{<<"myval">> => "xyz"}], bec_yml:decode(Yml))
+  after
+    os:unsetenv("TEST_VAL")
+  end.
+
+-spec missing_environment_variable(config()) -> ok.
+missing_environment_variable(_Config) ->
+  Yml = <<"myval: !env TEST_VAL\n">>,
+  os:unsetenv("TEST_VAL"),
+  ?assertThrow({yamerl_exception, _}, bec_yml:decode(Yml)).


### PR DESCRIPTION
This mechanism is intended for the handling of secrets: instead of having to store the secret in plain text in a `.yml` (or `.ymlt`) file, the value can be taken from an OS environment variable at the time the configuration is applied.