### PR TITLE
Remove unsupported webhook fields

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest]
-        otp-version: [23, 24, 25, 26]
+        otp-version: [25, 26]
     runs-on: ${{ matrix.platform }}
     container:
       image: erlang:${{ matrix.otp-version }}

--- a/rebar.config
+++ b/rebar.config
@@ -32,8 +32,7 @@
                                        ]
                            }
                          , { deps
-                           , [ {jesse,          "1.5.5"}
-                             , {meck,           "0.8.12"}
+                           , [ {meck,           "0.8.12"}
                              , {proper,         {git, "https://github.com/proper-testing/proper.git", {tag, "v1.3"}}}
                              , {proper_contrib, "0.3.2"}
                              , {redbug,         "1.2.1"}

--- a/scripts/docker-compose.yaml
+++ b/scripts/docker-compose.yaml
@@ -22,7 +22,7 @@ services:
       test: ['CMD', 'bash', '-c', 'curl -s http://localhost:7990/status | grep RUNNING']
       interval: 5s
       start_period: 10s
-      retries: 10
+      retries: 20
     mem_limit: 4G
 
 networks:

--- a/scripts/docker-compose.yaml
+++ b/scripts/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '2'
 
 services:
   bitbucket:
-    image: atlassian/bitbucket-server:7.17.1
+    image: atlassian/bitbucket-server:8.14.2
     restart: always
     networks:
       - bridge

--- a/src/bec_webhook_t.erl
+++ b/src/bec_webhook_t.erl
@@ -38,9 +38,11 @@
 from_map(#{ <<"configuration">> := Config
           , <<"events">>        := Events
           } = Map) ->
-  keys_to_atoms(Map#{ <<"configuration">> => keys_to_atoms(Config)
-                    , <<"events">>        => lists:sort(Events)
-                    }).
+  Map0 = maps:remove(<<"sslVerificationRequired">>, Map),
+  Map1 = maps:remove(<<"scopeType">>, Map0),
+  keys_to_atoms(Map1#{ <<"configuration">> => keys_to_atoms(Config)
+                     , <<"events">>        => lists:sort(Events)
+                     }).
 
 -spec to_map(webhook()) -> map().
 to_map(#{ configuration := Config

--- a/test/prop_api.erl
+++ b/test/prop_api.erl
@@ -396,7 +396,7 @@ get_webhooks_pre(S) ->
 get_webhooks_post(S, _Args, {ok, WebHooks0}) ->
   Generated = [id, createdDate, updatedDate],
   Webhooks = [lists:foldl(fun maps:remove/2, WH, Generated)|| WH <- WebHooks0],
-  ?assertEqual(lists:sort(Webhooks), lists:sort(maps:get(webhooks, S))),
+  ?assertEqual(lists:sort(maps:get(webhooks, S)), lists:sort(Webhooks)),
   true.
 
 %%------------------------------------------------------------------------------


### PR DESCRIPTION
The `sslVerificationRequired` and `scopeType` fields received from the `GET .../webhooks` API call are not supported by BEC right now. Remove them so they don't interfere with our tests.
