### PR TITLE
Avoid re-applying configuration due to users-groups changed order

### DIFF
--- a/test/bec_config_ss_SUITE.erl
+++ b/test/bec_config_ss_SUITE.erl
@@ -11,6 +11,7 @@
 -export([ to_wz_branch_reviewers_adds_default_mandatory/1 
         , to_wz_branch_reviewers_keeps_original_mandatory/1
         , to_wz_branch_reviewers_adds_default_mandatory_in_path/1
+        , to_wz_branch_reviewers_ordered_keys/1
         ]).
 
 %%==============================================================================
@@ -23,10 +24,11 @@ all() ->
   [ to_wz_branch_reviewers_adds_default_mandatory
   , to_wz_branch_reviewers_keeps_original_mandatory
   , to_wz_branch_reviewers_adds_default_mandatory_in_path
+  , to_wz_branch_reviewers_ordered_keys
   ].
 
 to_wz_branch_reviewers_adds_default_mandatory(_Config) ->
-  Reviewers = 
+  Reviewers =
     [ #{ <<"branch-id">> => <<"master">>
        , <<"groups">>    => []
        , <<"paths">>     => []
@@ -45,7 +47,7 @@ to_wz_branch_reviewers_adds_default_mandatory(_Config) ->
   ?assertEqual(ExpectedResult, bec_config_ss:to_wz_branch_reviewers(Reviewers)).
 
 to_wz_branch_reviewers_keeps_original_mandatory(_Config) ->
-  Reviewers = 
+  Reviewers =
     [ #{ <<"branch-id">>        => <<"master">>
        , <<"groups">>           => []
        , <<"paths">>            => []
@@ -66,7 +68,7 @@ to_wz_branch_reviewers_keeps_original_mandatory(_Config) ->
   ?assertEqual(ExpectedResult, bec_config_ss:to_wz_branch_reviewers(Reviewers)).
 
 to_wz_branch_reviewers_adds_default_mandatory_in_path(_Config) ->
-  Reviewers = 
+  Reviewers =
     [ #{ <<"branch-id">> => <<"master">>
        , <<"groups">>    => []
        , <<"paths">>     => [#{ <<"file-path-pattern">> => []
@@ -92,3 +94,34 @@ to_wz_branch_reviewers_adds_default_mandatory_in_path(_Config) ->
        }
       ],
   ?assertEqual(ExpectedResult, bec_config_ss:to_wz_branch_reviewers(Reviewers)).
+
+  to_wz_branch_reviewers_ordered_keys(_Config) ->
+    Reviewers =
+      [ #{ <<"branch-id">> => <<"master">>
+         , <<"groups">>    => [ <<"group.b">>, <<"group.a">> ]
+         , <<"paths">>     => [#{ <<"file-path-pattern">> => [ <<"path.b">>, <<"path.a">> ]
+                                , <<"users">> => [ <<"user.d">>, <<"user.c">> ]
+                                , <<"groups">> => [ <<"group.d">>, <<"group.c">> ]
+                                , <<"mandatory-users">>  => [ <<"user.f">>, <<"user.e">> ]
+                                , <<"mandatory-groups">> => [ <<"group.f">>, <<"group.e">> ]
+                              }]
+         , <<"users">>     => [ <<"user.b">>, <<"user.a">> ]
+         , <<"mandatory-users">>  => [ <<"user.h">>, <<"user.g">> ]
+         , <<"mandatory-groups">> => [ <<"group.h">>, <<"group.g">> ]
+         }
+      ],
+    ExpectedResult =
+      [ #{ 'branch-id'        => <<"master">>
+         , 'groups'           => [ <<"group.a">>, <<"group.b">> ]
+         , 'paths'            => [#{ 'file-path-pattern' => [ <<"path.a">>, <<"path.b">> ]
+                                   , 'users' => [ <<"user.c">>, <<"user.d">> ]
+                                   , 'groups' => [ <<"group.c">>, <<"group.d">> ]
+                                   , 'mandatory-users' => [ <<"user.e">>, <<"user.f">> ]
+                                   , 'mandatory-groups' => [ <<"group.e">>, <<"group.f">> ]
+                                   }]
+         , 'users'            => [ <<"user.a">>, <<"user.b">> ]
+         , 'mandatory-users'  => [ <<"user.g">>, <<"user.h">> ]
+         , 'mandatory-groups' => [ <<"group.g">>, <<"group.h">> ]
+         }
+        ],
+    ?assertEqual(ExpectedResult, bec_config_ss:to_wz_branch_reviewers(Reviewers)).

--- a/test/bec_config_ss_SUITE.erl
+++ b/test/bec_config_ss_SUITE.erl
@@ -113,7 +113,7 @@ to_wz_branch_reviewers_adds_default_mandatory_in_path(_Config) ->
     ExpectedResult =
       [ #{ 'branch-id'        => <<"master">>
          , 'groups'           => [ <<"group.a">>, <<"group.b">> ]
-         , 'paths'            => [#{ 'file-path-pattern' => [ <<"path.a">>, <<"path.b">> ]
+         , 'paths'            => [#{ 'file-path-pattern' => [ <<"path.b">>, <<"path.a">> ]
                                    , 'users' => [ <<"user.c">>, <<"user.d">> ]
                                    , 'groups' => [ <<"group.c">>, <<"group.d">> ]
                                    , 'mandatory-users' => [ <<"user.e">>, <<"user.f">> ]


### PR DESCRIPTION
When users and groups are not in alphabetical order in the wz_branch_reviewers section of the yml config file, the check between actual configuration retrieved by bitbucket api and the new one, provided in the yml file, fails. This happens because the relative info from bitbucket response are sorted, while the yml file object representation does not the same. This change aims to sort also the info coming from the yml file.