### PR TITLE
Allow setting webhook username and password

### DIFF
--- a/sample_repo_configuration.yml
+++ b/sample_repo_configuration.yml
@@ -152,6 +152,7 @@ webhooks:
     active: true
     url: http://my_other_endpoint
     configuration:
-      secret: !env MY_OTHER_SECRET
+      username: my_username
+      password: !env WEBHOOK_PASSWORD
     events:
       - pr:modified

--- a/src/bec_webhook_t.erl
+++ b/src/bec_webhook_t.erl
@@ -18,7 +18,10 @@
                     , createdDate   => pos_integer()
                     , updatedDate   => pos_integer()
                     , active        := boolean()
-                    , configuration := #{ secret := binary() }
+                    , configuration := #{ secret := binary()
+                                        , username := binary()
+                                        , password := binary()
+                                        }
                     , events        := [binary()]
                     , name          := binary()
                     , url           := binary()

--- a/test/bec_proper_gen.erl
+++ b/test/bec_proper_gen.erl
@@ -310,10 +310,19 @@ webhook_active() ->
 webhook_secret() ->
   non_empty(string_b()).
 
+webhook_username() ->
+  non_empty(string_b()).
+
+webhook_password() ->
+  non_empty(string_b()).
+
 webhook_config() ->
-  ?LET( Secret
-      , webhook_secret()
-      , #{ secret => Secret }).
+  ?LET({Secret, Username, Password}
+      , {webhook_secret(), webhook_username(), webhook_password()}
+      , #{ secret => Secret
+        , username => Username
+        , password => Password
+        }).
 
 webhook_event() ->
   oneof([<<"pr:modified">>, <<"repo:refs_changed">>]).


### PR DESCRIPTION
Heads up that I haven't actually ran this yet, as I was hoping to get away with not having to install Erlang and relying on the CI to build and test this, since I'm hoping the change is rather straightforward.

The webhook API accepts `username` and `password` in addition to `secret`. I verified this by manually modifying it in the UI and inspecting the request.