### PR TITLE
Allow testing the "public" repo flag, take 2

### DIFF
--- a/test/bec_proper_gen.erl
+++ b/test/bec_proper_gen.erl
@@ -415,6 +415,8 @@ is_config_key_supported('wz-pr-restrictions', Features) ->
   maps:get(wz, Features, false);
 is_config_key_supported('wz-branch-reviewers', Features) ->
   maps:get(wz, Features, false);
+is_config_key_supported('public', _Features) ->
+  bec_test_utils:is_public_repo_supported();
 is_config_key_supported(_, _) ->
   true.
 
@@ -448,13 +450,7 @@ config_keys() ->
 config_value('project')             -> bec_test_utils:bitbucket_project_key();
 config_value('repo')                -> bec_test_utils:bitbucket_repo_slug();
 config_value('default-branch')      -> branch_id();
-config_value('public')              ->
-  case os:getenv("BEC_SKIP_PUBLIC") of
-    Value when is_list(Value) ->
-      [];
-    false ->
-      bool()
-  end;
+config_value('public')              -> bool();
 config_value('users')               -> ss_permission_users();
 config_value('groups')              -> ss_permission_groups();
 config_value('branch-restrictions') -> ss_branch_restrictions();

--- a/test/bec_test_utils.erl
+++ b/test/bec_test_utils.erl
@@ -5,7 +5,7 @@
         , init_logging/0
         , flush_logging/0
         , is_wz_supported/0
-
+        , is_public_repo_supported/0
         , bitbucket_server_url/0
         , bitbucket_project_key/0
         , bitbucket_repo_slug/0
@@ -170,6 +170,14 @@ is_wz_supported() ->
   catch _:_ ->
       ?LOG_ERROR("Workzone plugin is not supported. Corresponding tests will not be run."),
       false
+  end.
+
+%% Set BEC_SKIP_PUBLIC environment variable to a non-empty value to
+%% disable testing of the "public" attribute for repos.
+is_public_repo_supported() ->
+  case os:getenv("BEC_SKIP_PUBLIC") of
+    [_|_] -> false;
+    _ -> true
   end.
 
 -spec bitbucket_server_url() -> binary().

--- a/test/prop_api.erl
+++ b/test/prop_api.erl
@@ -74,7 +74,10 @@ set_default_branch_post(_S, _Args, ok) ->
 %% get_public/2
 %%------------------------------------------------------------------------------
 get_public(Key, Slug) ->
-  bitbucket:get_public(Key, Slug).
+  case bec_test_utils:is_public_repo_supported() of
+    true -> bitbucket:get_public(Key, Slug);
+    false -> {ok, true}
+  end.
 
 get_public_args(S) ->
   [maps:get(project_key, S), maps:get(repo_slug, S)].
@@ -86,14 +89,22 @@ get_public_pre(S) ->
   maps:is_key(public, S).
 
 get_public_post(S, _Args, {ok, Public}) ->
-  ?assertEqual(Public, maps:get(public, S)),
-  true.
+  case bec_test_utils:is_public_repo_supported() of
+    true ->
+      ?assertEqual(Public, maps:get(public, S)),
+      true;
+    false ->
+      true
+  end.
 
 %%------------------------------------------------------------------------------
 %% set_public/3
 %%------------------------------------------------------------------------------
 set_public(Key, Slug, Public) ->
-  bitbucket:set_public(Key, Slug, Public).
+  case bec_test_utils:is_public_repo_supported() of
+    true -> bitbucket:set_public(Key, Slug, Public);
+    false -> ok
+  end.
 
 set_public_args(S) ->
   [maps:get(project_key, S), maps:get(repo_slug, S), bool()].
@@ -101,8 +112,14 @@ set_public_args(S) ->
 set_public_next(S, _R, [_Key, _Slug, Branch]) ->
   maps:put(public, Branch, S).
 
-set_public_post(_S, _Args, ok) ->
-  true.
+set_public_post(_S, _Args, Result) ->
+  case bec_test_utils:is_public_repo_supported() of
+    true ->
+      ?assertEqual(Result, ok),
+      true;
+    _ ->
+      true
+  end.
 
 %%------------------------------------------------------------------------------
 %% get_users/2


### PR DESCRIPTION
Another attempt att allowing test environments to skip the "public" attribute. The internal Klarna test environment is run against a Bitbucket server where new repos cannot be set to public, and this means that we have to have a way to disable this attribute.
